### PR TITLE
Add torch build-time dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# Default setuptools and wheel requirements from
+# https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour
+requires = ["setuptools>=40.8.0", "wheel", "torch"]


### PR DESCRIPTION
Allows installing this as a normal dependency, without requiring torch
to be installed manually beforehand.

I'm not sure how this will interact with pinned torch versions that are
not the latest, but this looks OK for now.